### PR TITLE
callApi doesn't accept Long inputs, which are needed for timestamps.

### DIFF
--- a/Cloudinary/src/com/cloudinary/Uploader.java
+++ b/Cloudinary/src/com/cloudinary/Uploader.java
@@ -243,7 +243,7 @@ public class Uploader {
 
 		// Remove blank parameters
 		for (Map.Entry<String, Object> param : params.entrySet()) {
-			if (param.getValue() instanceof String || param.getValue() instanceof Integer) { 
+			if (param.getValue() instanceof String || param.getValue() instanceof Integer || param.getValue() instanceof Long) { 
 				String value = Cloudinary.asString(param.getValue());
 				if (!TextUtils.isEmpty(value)) {
 					multipart.addFormField(param.getKey(), value);


### PR DESCRIPTION
Option inputs of type Long are ignored with line Line 246 of Uploader.java:

Lines 244-256 (https://github.com/cloudinary/cloudinary_android/blob/master/Cloudinary/src/com/cloudinary/Uploader.java#L244-L256)

```
        // Remove blank parameters
        for (Map.Entry<String, Object> param : params.entrySet()) {
            if (param.getValue() instanceof String || param.getValue() instanceof Integer) { 
                String value = Cloudinary.asString(param.getValue());
                if (!TextUtils.isEmpty(value)) {
                    multipart.addFormField(param.getKey(), value);
                }
            } else if (param.getValue() instanceof Collection) {
                for (Object value : (Collection) param.getValue()) {
                    multipart.addFormField(param.getKey()+"[]", Cloudinary.asString(value));                    
                }
            }
        }
```

Long is useful for timestamps because they are very large numbers. The workaround is to pass timestamp in as a String.
