### PR TITLE
Adding proguard rule to the library itself, Closes  #12

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -17,6 +17,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'proguard-rules.pro'
         }
     }
 

--- a/lib/proguard-rules.pro
+++ b/lib/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.cloudinary.android.*Strategy


### PR DESCRIPTION
This is to ship the proguard rule with the library itself and not have developers waste time to figure it out on their own.

Based on this issue https://github.com/cloudinary/cloudinary_android/issues/12