### PR TITLE
Fix sample app

### DIFF
--- a/ui/src/main/java/com/cloudinary/android/uploadwidget/UploadWidget.java
+++ b/ui/src/main/java/com/cloudinary/android/uploadwidget/UploadWidget.java
@@ -125,7 +125,7 @@ public class UploadWidget {
      * @param requestCode A request code to start the native android picker with.
      */
     public static void openMediaChooser(Activity activity, int requestCode) {
-        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);

--- a/ui/src/main/java/com/cloudinary/android/uploadwidget/ui/UploadWidgetActivity.java
+++ b/ui/src/main/java/com/cloudinary/android/uploadwidget/ui/UploadWidgetActivity.java
@@ -72,7 +72,7 @@ public class UploadWidgetActivity extends AppCompatActivity implements UploadWid
                 ArrayList<Uri> uris = extractImageUris(data);
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                    final int takeFlags = data.getFlags() & (Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+                    final int takeFlags = data.getFlags() & (Intent.FLAG_GRANT_READ_URI_PERMISSION);
                     for (Uri uri : uris) {
                         if (DocumentsContract.isDocumentUri(this, uri)) {
                             getContentResolver().takePersistableUriPermission(uri, takeFlags);


### PR DESCRIPTION
Sample app is currently broken, picking an image from the upload widget fails due to permission denial
A little research lead to StackOverFlow
2 changes were made in order to make it work
First of all we need to use `Intent.ACTION_OPEN_DOCUMENT` instead of `Intent.ACTION_GET_CONTENT`
`ACTION_GET_CONTENT` saves the uri for a short period and we need more than that when we upload an image
With that comes the permission: `FLAG_GRANT_READ_URI_PERMISSION` , that one replaced  `FLAG_GRANT_PERSISTABLE_URI_PERMISSION` due to a different approach in the intent action.