### PR TITLE
Bump dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,6 @@ test-output/
 
 # Maven
 
-target/
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
 language: android
+jdk:
+  - openjdk11
 dist: trusty
 sudo: required
 
 global:
-    # switch glibc to a memory conserving mode
-    - MALLOC_ARENA_MAX=2
-    # wait up to 10 minutes for adb to connect to emulator
-    - ADB_INSTALL_TIMEOUT=10
+  # switch glibc to a memory conserving mode
+  - MALLOC_ARENA_MAX=2
+  # wait up to 10 minutes for adb to connect to emulator
+  - ADB_INSTALL_TIMEOUT=10
+env:
+  global:
+    - TARGET_VERSION=30
+    - ANDROID_BUILD_TOOLS_VERSION=30.0.2
+    - ANDROID_HOME=~/android-sdk
 android:
   licenses:
     - 'android-sdk-preview-license-.+'
@@ -15,9 +22,10 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-29.0.2
+    - build-tools-30.0.2
     - android-21
-    - android-29
+    - android-31
+    - android ${TARGET_VERSION}
     - extra-google-google_play_services
     - extra-google-m2repository
     - extra-android-m2repository
@@ -25,7 +33,11 @@ android:
     - sys-img-armeabi-v7a-android-21
 
 before_install:
-  - yes | sdkmanager "platforms;android-28"
+  - touch $HOME/.android/repositories.cfg
+  - wget "https://dl.google.com/android/repository/commandlinetools-linux-7302050_latest.zip" -O commandlinetools.zip
+  - unzip commandlinetools.zip -d $ANDROID_HOME/
+  - yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager "platforms;android-${TARGET_VERSION}" --sdk_root=$ANDROID_HOME
+  - yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" --sdk_root=$ANDROID_HOME
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -34,9 +46,6 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-
-jdk:
-  - oraclejdk8
 
 # Emulator Management: Create, Start and Wait
 before_script:
@@ -51,4 +60,3 @@ notifications:
   email:
     recipients:
       - sdk_developers@cloudinary.com
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ android:
     - addon-google_apis-google-25
     - sys-img-armeabi-v7a-android-21
 
+#taken from: https://travis-ci.community/t/sdkmanager-to-run-with-java-11/11978/2
 before_install:
   - touch $HOME/.android/repositories.cfg
   - wget "https://dl.google.com/android/repository/commandlinetools-linux-7302050_latest.zip" -O commandlinetools.zip

--- a/all/build.gradle
+++ b/all/build.gradle
@@ -1,16 +1,15 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion 31
+    buildToolsVersion "30.0.2"
 
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 29
+        minSdkVersion 19
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
     }
@@ -22,6 +21,11 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
 }
 
 dependencies {
@@ -31,10 +35,10 @@ dependencies {
     api project(path: ':ui')
     api project(path: ':download')
 
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,10 @@ allprojects {
             google()
             mavenCentral()
             maven { url "https://plugins.gradle.org/m2/" }
-            maven { url 'https://google.bintray.com/exoplayer/' }
         }
 
         dependencies {
-            classpath 'com.android.tools.build:gradle:4.0.0'
+            classpath 'com.android.tools.build:gradle:7.0.4'
             classpath "de.marcphilipp.gradle:nexus-publish-plugin:0.4.0"
             classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.1"
             classpath 'digital.wup:android-maven-publish:3.6.2'

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,9 @@ allprojects {
     buildscript {
         repositories {
             google()
-            jcenter()
-            maven {
-                url "https://plugins.gradle.org/m2/"
-            }
+            mavenCentral()
+            maven { url "https://plugins.gradle.org/m2/" }
+            maven { url 'https://google.bintray.com/exoplayer/' }
         }
 
         dependencies {
@@ -23,7 +22,6 @@ allprojects {
 
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,17 +1,17 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion 31
+    buildToolsVersion "30.0.2"
 
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 29
+        minSdkVersion 19
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
+        multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
         // filter in the api credentials before building but without changing original source
         // files - to make sure the credentials are not checked into source control.
         // The url is taken from a property or environment variable:
@@ -24,6 +24,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             consumerProguardFiles 'proguard-rules.pro'
         }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 
@@ -43,24 +48,24 @@ tasks.matching { it.name.startsWith("connected") || it.name.startsWith("test")}.
 dependencies {
     api "com.cloudinary:cloudinary-core:${cloudinaryLibsVersion}"
 
-    implementation 'androidx.core:core:1.2.0'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.core:core:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.4.0'
     implementation('com.evernote:android-job:1.4.2', {
         exclude group: 'com.android.support', module: 'support-compat'
     })
 
-    testImplementation 'androidx.test.ext:junit:1.1.1'
+    testImplementation 'androidx.test.ext:junit:1.1.3'
     testImplementation "com.cloudinary:cloudinary-test-common:${cloudinaryLibsVersion}"
-    androidTestImplementation 'org.awaitility:awaitility:3.0.0'
-    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
+    androidTestImplementation 'org.awaitility:awaitility:3.1.6'
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.4.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    androidTestImplementation 'androidx.annotation:annotation:1.1.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation "org.hamcrest:hamcrest-library:1.3"
+    androidTestImplementation 'androidx.annotation:annotation:1.2.0'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test:rules:1.4.0'
+    androidTestImplementation "org.hamcrest:hamcrest-library:2.2"
 }
 
 ext {

--- a/core/src/androidTest/AndroidManifest.xml
+++ b/core/src/androidTest/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--suppress AndroidDomInspection -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.cloudinary.android.test"
     android:versionCode="1"

--- a/core/src/androidTest/java/com/cloudinary/android/UploaderTest.java
+++ b/core/src/androidTest/java/com/cloudinary/android/UploaderTest.java
@@ -265,7 +265,7 @@ public class UploaderTest extends AbstractTest {
         final String sprite_test_tag = String.format("sprite_test_tag_%d", new java.util.Date().getTime());
         cloudinary.uploader().upload(getAssetStream(TEST_IMAGE), ObjectUtils.asMap("tags", sprite_test_tag, "public_id", "sprite_test_tag_1"));
         cloudinary.uploader().upload(getAssetStream(TEST_IMAGE), ObjectUtils.asMap("tags", sprite_test_tag, "public_id", "sprite_test_tag_2"));
-        JSONObject result = new JSONObject(cloudinary.uploader().generateSprite(sprite_test_tag, ObjectUtils.emptyMap()));
+        JSONObject result = new JSONObject(cloudinary.uploader().generateSprite(sprite_test_tag, new HashMap()));
         Assert.assertEquals(2, result.getJSONObject("image_infos").length());
         result = new JSONObject(cloudinary.uploader().generateSprite(sprite_test_tag, ObjectUtils.asMap("transformation", "w_100")));
         assertTrue((result.getString("css_url")).contains("w_100"));
@@ -280,7 +280,7 @@ public class UploaderTest extends AbstractTest {
             return;
         cloudinary.uploader().upload(getAssetStream(TEST_IMAGE), ObjectUtils.asMap("tags", "multi_test_tag", "public_id", "multi_test_tag_1"));
         cloudinary.uploader().upload(getAssetStream(TEST_IMAGE), ObjectUtils.asMap("tags", "multi_test_tag", "public_id", "multi_test_tag_2"));
-        JSONObject result = new JSONObject(cloudinary.uploader().multi("multi_test_tag", ObjectUtils.emptyMap()));
+        JSONObject result = new JSONObject(cloudinary.uploader().multi("multi_test_tag", new HashMap()));
         assertTrue((result.getString("url")).endsWith(".gif"));
         result = new JSONObject(cloudinary.uploader().multi("multi_test_tag", ObjectUtils.asMap("transformation", "w_100")));
         assertTrue((result.getString("url")).contains("w_100"));

--- a/core/src/main/java/com/cloudinary/android/ApiStrategy.java
+++ b/core/src/main/java/com/cloudinary/android/ApiStrategy.java
@@ -8,7 +8,6 @@ import com.cloudinary.strategies.AbstractApiStrategy;
 
 public class ApiStrategy extends AbstractApiStrategy {
 
-    @SuppressWarnings("rawtypes")
     @Override
     public ApiResponse callApi(HttpMethod method, Iterable<String> uri, Map<String, ?> params, Map options) throws Exception {
         throw new Exception("Administration API is not supported for mobile applications.");

--- a/download/build.gradle
+++ b/download/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion 31
+    buildToolsVersion "30.0.2"
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 29
+        minSdkVersion 19
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
-
+        multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
 
@@ -23,19 +23,24 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
 }
 
 dependencies {
     implementation project(':core')
 
     compileOnly 'com.squareup.picasso:picasso:2.71828'
-    compileOnly 'com.facebook.fresco:fresco:2.6.0'
-    compileOnly 'com.github.bumptech.glide:glide:4.11.0'
+    implementation 'com.facebook.fresco:fresco:2.6.0'
+    compileOnly 'com.github.bumptech.glide:glide:4.12.0'
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'org.mockito:mockito-android:2.24.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'org.mockito:mockito-android:4.2.0'
 }
 
 ext {

--- a/download/build.gradle
+++ b/download/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation project(':core')
 
     compileOnly 'com.squareup.picasso:picasso:2.71828'
-    compileOnly 'com.facebook.fresco:fresco:2.2.0'
+    compileOnly 'com.facebook.fresco:fresco:2.6.0'
     compileOnly 'com.github.bumptech.glide:glide:4.11.0'
 
     testImplementation 'junit:junit:4.12'

--- a/glide-integration/build.gradle
+++ b/glide-integration/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion 31
+    buildToolsVersion "30.0.2"
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 29
+        minSdkVersion 19
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
-
+        multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
     }
@@ -21,16 +21,21 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
 }
 
 dependencies {
     implementation project(':core')
-    implementation 'com.github.bumptech.glide:glide:4.11.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'org.mockito:mockito-android:2.24.0'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'org.mockito:mockito-android:4.2.0'
 }
 
 ext {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ developerEmail=info@cloudinary.com
 # These two properties must use these exact names to be compatible with 'gradle install' plugin.
 group=com.cloudinary
 version=1.30.0
-cloudinaryLibsVersion=1.26.0
+cloudinaryLibsVersion=1.30.0
 
 org.gradle.jvmargs=-Xmx1024m
 gnsp.disableApplyOnlyOnRootProjectEnforcement=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
-#Mon Sep 09 15:05:12 IDT 2019
-#Thu Sep 12 13:03:54 IDT 2019
+#Wed Jan 19 11:45:39 IST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/preprocess/build.gradle
+++ b/preprocess/build.gradle
@@ -1,15 +1,16 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion 31
+    buildToolsVersion "30.0.2"
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 29
+        minSdkVersion 19
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
-
+        android.compileOptions.sourceCompatibility 1.8
+        android.compileOptions.targetCompatibility 1.8
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
 
@@ -26,19 +27,24 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':core')
 
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.linkedin.android.litr:litr:1.4.16'
 
-    testImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation 'org.awaitility:awaitility:3.0.0'
+    testImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'org.awaitility:awaitility:3.1.6'
 }
 
 ext {

--- a/preprocess/build.gradle
+++ b/preprocess/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation project(':core')
 
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.linkedin.android.litr:litr:1.1.0'
+    implementation 'com.linkedin.android.litr:litr:1.4.16'
 
     testImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'

--- a/preprocess/src/androidTest/AndroidManifest.xml
+++ b/preprocess/src/androidTest/AndroidManifest.xml
@@ -6,6 +6,7 @@
 
     <uses-sdk android:minSdkVersion="9" />
 
+    <!--suppress AndroidDomInspection -->
     <instrumentation
         android:name="androidx.test.runner.AndroidJUnitRunner"
         android:targetPackage="com.cloudinary.android.preprocess" />

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -11,7 +11,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
+        multiDexEnabled true
         // filter in the api credentials before building but without changing original source
         // files - to make sure the  credentials are not checked into source control.
         // The url (without api secret!) is taken from a gradle property  defined in
@@ -34,7 +34,7 @@ android {
 
 dependencies {
     implementation project(':all')
-
+    implementation 'com.android.support:multidex:1.0.3'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
@@ -45,9 +45,9 @@ dependencies {
 
     implementation 'com.github.bumptech.glide:glide:4.11.0'
 
-    implementation ('com.google.android.exoplayer:exoplayer:2.9.5', {
-        exclude group: "com.android.support"
-    })
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.14.0'
+    implementation 'com.google.android.exoplayer:exoplayer-dash:2.14.0'
+    implementation 'com.google.android.exoplayer:exoplayer-ui:2.14.0'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
@@ -55,5 +55,4 @@ dependencies {
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
     })
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.2.0'
-
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion 31
+    buildToolsVersion "30.0.2"
 
     defaultConfig {
         applicationId "com.cloudinary.android.sample"
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -28,6 +28,7 @@ android {
     }
 
     compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
 }
@@ -35,24 +36,24 @@ android {
 dependencies {
     implementation project(':all')
     implementation 'com.android.support:multidex:1.0.3'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.recyclerview:recyclerview:1.1.0'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
+    implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.exifinterface:exifinterface:1.2.0'
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
+    implementation 'androidx.exifinterface:exifinterface:1.3.3'
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
 
-    implementation 'com.github.bumptech.glide:glide:4.11.0'
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
 
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.14.0'
-    implementation 'com.google.android.exoplayer:exoplayer-dash:2.14.0'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.14.0'
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.16.0'
+    implementation 'com.google.android.exoplayer:exoplayer-dash:2.16.0'
+    implementation 'com.google.android.exoplayer:exoplayer-ui:2.16.0'
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.4.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
     })
-    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
 }

--- a/sample/proguard-rules.pro
+++ b/sample/proguard-rules.pro
@@ -21,7 +21,7 @@
 -dontwarn javax.annotation.**
 -dontwarn org.conscrypt.**
 # A resource is loaded with a relative path so the package of this class must be preserved.
--keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+#-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
 
 # Cloudinary:
 -keep class com.cloudinary.android.*Strategy

--- a/sample/src/androidTest/java/cloudinary/android/sample/UploadWidgetTest.java
+++ b/sample/src/androidTest/java/cloudinary/android/sample/UploadWidgetTest.java
@@ -39,7 +39,7 @@ public class UploadWidgetTest {
     public IntentsTestRule<MainActivity> intentsTestRule = new IntentsTestRule<>(MainActivity.class);
 
     // TODO: Fix UI tests for travis
-    @Ignore
+    @Ignore("Not supported by Travis")
     @Test
     public void testUploadWidget() {
         UploadWidget.startActivity(intentsTestRule.getActivity(),

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         <activity
             android:name=".app.MainActivity"
             android:label="@string/app_name"
+            android:exported="true"
             android:launchMode="singleTop"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar">
@@ -35,11 +36,13 @@
         </activity>
         <activity
             android:name=".app.ImageActivity"
+            android:exported="true"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar" />
 
-        <service android:name=".app.CloudinaryService" />
+        <service android:name=".app.CloudinaryService"
+            android:exported="false"/>
 
         <meta-data
             android:name="cloudinaryCallbackService"

--- a/sample/src/main/java/com/cloudinary/android/sample/app/CloudinaryService.java
+++ b/sample/src/main/java/com/cloudinary/android/sample/app/CloudinaryService.java
@@ -1,5 +1,6 @@
 package com.cloudinary.android.sample.app;
 
+import android.annotation.SuppressLint;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -42,6 +43,7 @@ public class CloudinaryService extends ListenerService {
     private Notification.Builder builder;
     private Handler backgroundThreadHandler;
 
+    @SuppressLint("UnspecifiedImmutableFlag")
     @Override
     public void onCreate() {
         super.onCreate();
@@ -70,8 +72,9 @@ public class CloudinaryService extends ListenerService {
         return null;
     }
 
+    @SuppressLint("UnspecifiedImmutableFlag")
     private Notification.Builder getBuilder(String requestId, Resource.UploadStatus status) {
-        Notification.Builder builder = new Notification.Builder(this)
+         Notification.Builder builder = new Notification.Builder(this)
                 .setSmallIcon(R.drawable.ic_launcher)
                 .setAutoCancel(true)
                 .setContentIntent(PendingIntent.getActivity(this, 1234,

--- a/sample/src/main/java/com/cloudinary/android/sample/app/ImageActivity.java
+++ b/sample/src/main/java/com/cloudinary/android/sample/app/ImageActivity.java
@@ -1,5 +1,6 @@
 package com.cloudinary.android.sample.app;
 
+import android.annotation.SuppressLint;
 import android.content.ClipData;
 import android.content.Intent;
 import android.net.Uri;
@@ -19,7 +20,6 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.OrientationHelper;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.cloudinary.Url;
@@ -31,26 +31,19 @@ import com.cloudinary.android.sample.core.CloudinaryHelper;
 import com.cloudinary.android.sample.model.EffectData;
 import com.cloudinary.android.sample.model.Resource;
 import com.cloudinary.utils.StringUtils;
-import com.google.android.exoplayer2.DefaultLoadControl;
-import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayer;
-import com.google.android.exoplayer2.LoadControl;
+import com.google.android.exoplayer2.MediaItem;
+import com.google.android.exoplayer2.PlaybackException;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
 import com.google.android.exoplayer2.extractor.ExtractorsFactory;
 import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.source.TrackGroupArray;
-import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
-import com.google.android.exoplayer2.trackselection.ExoTrackSelection;
-import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
-import com.google.android.exoplayer2.trackselection.TrackSelector;
 import com.google.android.exoplayer2.ui.PlayerView;
-import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DataSource;
-import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.util.Util;
 import com.google.android.material.snackbar.Snackbar;
@@ -104,16 +97,7 @@ public class ImageActivity extends AppCompatActivity {
 
 
     private void initExoPlayer() {
-//        DefaultBandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
-
-        // track selector is used to navigate between
-        // video using a default seekbar.
-//        TrackSelector trackSelector = new DefaultTrackSelector(new AdaptiveTrackSelection.Factory(bandwidthMeter));
-
-        // we are adding our track selector to exoplayer.
         exoPlayer = new SimpleExoPlayer.Builder(this).build();
-
-//        exoPlayer = ExoPlayerFactory.new SimpleInstance(this, trackSelector);
         exoPlayerView = ((PlayerView) findViewById(R.id.exoPlayer));
         exoPlayerView.setPlayer(exoPlayer);
 
@@ -137,9 +121,9 @@ public class ImageActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onPlayerError(ExoPlaybackException e) {
+            public void onPlayerError(PlaybackException error) {
                 progressBar.setVisibility(View.GONE);
-                Toast.makeText(ImageActivity.this, "Error: " + e.getMessage(), Toast.LENGTH_LONG).show();
+                Toast.makeText(ImageActivity.this, "Error: " + error.getMessage(), Toast.LENGTH_LONG).show();
             }
 
             @Override
@@ -193,15 +177,18 @@ public class ImageActivity extends AppCompatActivity {
         imageView.setVisibility(View.GONE);
         final DataSource.Factory dataSourceFactory = new DefaultDataSourceFactory(this, Util.getUserAgent(this, "Cloudinary Sample App"), null);
         final ExtractorsFactory extractorsFactory = new DefaultExtractorsFactory();
-        Url baseUrl = MediaManager.get().url().resourceType("video").publicId(data.getPublicId()).transformation(data.getTransformation());
+        Url baseUrl = MediaManager.get().url().secure(true).resourceType("video").publicId(data.getPublicId()).transformation(data.getTransformation());
         MediaManager.get().responsiveUrl(exoPlayerView, baseUrl, FIT, new ResponsiveUrl.Callback() {
             @Override
             public void onUrlReady(Url url) {
-                String urlString = url.generate();
+                String urlString = url.secure(true).generate();
                 currentUrl = urlString;
-//                MediaSource videoSource = new MediaSourceFac(Uri.parse(urlString), dataSourceFactory, extractorsFactory, null, null);
+                MediaItem mediaItem = new MediaItem.Builder().setUri(Uri.parse(urlString)).build();
+                MediaSource videoSource = new ProgressiveMediaSource
+                        .Factory(dataSourceFactory, extractorsFactory).createMediaSource(mediaItem);
                 exoPlayer.addListener(listener);
-//                exoPlayer.prepare(videoSource);
+                exoPlayer.setMediaSource(videoSource);
+                exoPlayer.getPlayWhenReady();
             }
         });
     }
@@ -239,18 +226,17 @@ public class ImageActivity extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                onBackPressed();
-                return true;
-            case R.id.menu_url:
-                if (StringUtils.isNotBlank(currentUrl)) {
-                    openUrlWithToast(currentUrl);
-                }
-
-                return true;
+        if (item.getItemId() == android.R.id.home) {
+            onBackPressed();
+            return true;
         }
+        if (item.getItemId() == R.id.menu_url) {
+            if (StringUtils.isNotBlank(currentUrl)) {
+                openUrlWithToast(currentUrl);
+            }
 
+            return true;
+        }
         return super.onOptionsItemSelected(item);
     }
 

--- a/sample/src/main/java/com/cloudinary/android/sample/app/ImageActivity.java
+++ b/sample/src/main/java/com/cloudinary/android/sample/app/ImageActivity.java
@@ -4,6 +4,7 @@ import android.content.ClipData;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Handler;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -30,22 +31,23 @@ import com.cloudinary.android.sample.core.CloudinaryHelper;
 import com.cloudinary.android.sample.model.EffectData;
 import com.cloudinary.android.sample.model.Resource;
 import com.cloudinary.utils.StringUtils;
+import com.google.android.exoplayer2.DefaultLoadControl;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayer;
-import com.google.android.exoplayer2.ExoPlayerFactory;
+import com.google.android.exoplayer2.LoadControl;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
 import com.google.android.exoplayer2.extractor.ExtractorsFactory;
-import com.google.android.exoplayer2.source.ExtractorMediaSource;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
+import com.google.android.exoplayer2.trackselection.ExoTrackSelection;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
-import com.google.android.exoplayer2.ui.SimpleExoPlayerView;
+import com.google.android.exoplayer2.ui.PlayerView;
 import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
@@ -67,7 +69,7 @@ public class ImageActivity extends AppCompatActivity {
     private TextView descriptionTextView;
     private ProgressBar progressBar;
     private SimpleExoPlayer exoPlayer;
-    private SimpleExoPlayerView exoPlayerView;
+    private PlayerView exoPlayerView;
     private ExoPlayer.EventListener listener;
     private String currentUrl = null;
 
@@ -85,7 +87,7 @@ public class ImageActivity extends AppCompatActivity {
         descriptionTextView = (TextView) findViewById(R.id.effectDescription);
         recyclerView = (RecyclerView) findViewById(R.id.effectsGallery);
         recyclerView.setHasFixedSize(true);
-        LinearLayoutManager layoutManager = new LinearLayoutManager(this, OrientationHelper.HORIZONTAL, false);
+        LinearLayoutManager layoutManager = new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false);
         recyclerView.setLayoutManager(layoutManager);
 
         initExoPlayer();
@@ -102,14 +104,17 @@ public class ImageActivity extends AppCompatActivity {
 
 
     private void initExoPlayer() {
-        BandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
-        TrackSelection.Factory videoTrackSelectionFactory =
-                new AdaptiveTrackSelection.Factory(bandwidthMeter);
-        TrackSelector trackSelector =
-                new DefaultTrackSelector(videoTrackSelectionFactory);
+//        DefaultBandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
 
-        exoPlayer = ExoPlayerFactory.newSimpleInstance(this, trackSelector);
-        exoPlayerView = ((SimpleExoPlayerView) findViewById(R.id.exoPlayer));
+        // track selector is used to navigate between
+        // video using a default seekbar.
+//        TrackSelector trackSelector = new DefaultTrackSelector(new AdaptiveTrackSelection.Factory(bandwidthMeter));
+
+        // we are adding our track selector to exoplayer.
+        exoPlayer = new SimpleExoPlayer.Builder(this).build();
+
+//        exoPlayer = ExoPlayerFactory.new SimpleInstance(this, trackSelector);
+        exoPlayerView = ((PlayerView) findViewById(R.id.exoPlayer));
         exoPlayerView.setPlayer(exoPlayer);
 
         listener = new ExoPlayer.EventListener() {
@@ -194,9 +199,9 @@ public class ImageActivity extends AppCompatActivity {
             public void onUrlReady(Url url) {
                 String urlString = url.generate();
                 currentUrl = urlString;
-                MediaSource videoSource = new ExtractorMediaSource(Uri.parse(urlString), dataSourceFactory, extractorsFactory, null, null);
+//                MediaSource videoSource = new MediaSourceFac(Uri.parse(urlString), dataSourceFactory, extractorsFactory, null, null);
                 exoPlayer.addListener(listener);
-                exoPlayer.prepare(videoSource);
+//                exoPlayer.prepare(videoSource);
             }
         });
     }

--- a/sample/src/main/java/com/cloudinary/android/sample/app/MainActivity.java
+++ b/sample/src/main/java/com/cloudinary/android/sample/app/MainActivity.java
@@ -1,5 +1,6 @@
 package com.cloudinary.android.sample.app;
 
+import android.annotation.SuppressLint;
 import android.content.BroadcastReceiver;
 import android.content.ClipData;
 import android.content.Context;
@@ -24,6 +25,7 @@ import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
 import com.cloudinary.android.MediaManager;
@@ -195,18 +197,18 @@ public class MainActivity extends AppCompatActivity implements ResourcesAdapter.
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_remove_from_local_album:
-                new ClearMediaFromDeviceDialogFragment().show(getSupportFragmentManager(), "ClearMediaDialogTag");
-                return true;
-            case R.id.menu_sync:
-                syncCloudinary();
-                return true;
-            case R.id.menu_remove_from_cloud:
-                new ClearMediaFromEverywhereDialogFragment().show(getSupportFragmentManager(), "ClearRemoteMediaDialogTag");
-                return true;
+        if (item.getItemId() == R.id.menu_remove_from_local_album) {
+            new ClearMediaFromDeviceDialogFragment().show(getSupportFragmentManager(), "ClearMediaDialogTag");
+            return true;
         }
-
+        if (item.getItemId() == R.id.menu_sync) {
+            syncCloudinary();
+            return true;
+        }
+        if (item.getItemId() == R.id.menu_sync) {
+            new ClearMediaFromEverywhereDialogFragment().show(getSupportFragmentManager(), "ClearRemoteMediaDialogTag");
+            return true;
+        }
         return super.onOptionsItemSelected(item);
     }
 

--- a/sample/src/main/java/com/cloudinary/android/sample/app/Utils.java
+++ b/sample/src/main/java/com/cloudinary/android/sample/app/Utils.java
@@ -1,5 +1,6 @@
 package com.cloudinary.android.sample.app;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.Context;
@@ -100,6 +101,7 @@ public class Utils {
         return point.x;
     }
 
+    @SuppressLint("Range")
     public static Pair<String, String> getResourceNameAndType(Context context, Uri uri) {
         Cursor cursor = null;
         String type = null;

--- a/sample/src/main/java/com/cloudinary/android/sample/persist/CloudinarySqliteHelper.java
+++ b/sample/src/main/java/com/cloudinary/android/sample/persist/CloudinarySqliteHelper.java
@@ -1,5 +1,6 @@
 package com.cloudinary.android.sample.persist;
 
+import android.annotation.SuppressLint;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -165,6 +166,7 @@ public class CloudinarySqliteHelper extends SQLiteOpenHelper {
         getWritableDatabase().execSQL("DELETE FROM " + TABLE + " WHERE " + LOCAL_ID_COL + "=?", new Object[]{localId});
     }
 
+    @SuppressLint("Range")
     public String getLocalUri(String requestId) {
         Cursor cursor = getReadableDatabase().query(TABLE, null, REQUEST_ID_COL + "=?", new String[]{requestId}, null, null, null);
         if (cursor.moveToFirst()) {

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -27,7 +27,7 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.viewpager.widget.ViewPager xmlns:android="http://schemas.android.com/apk/res/android"
+    <androidx.viewpager.widget.ViewPager
         android:id="@+id/pager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -40,6 +40,7 @@
         android:layout_gravity="bottom|end"
         android:layout_margin="@dimen/fab_margin"
         app:backgroundTint="@color/addButtonColor"
-        app:srcCompat="@drawable/ic_add_white_48dp" />
+        app:srcCompat="@drawable/ic_add_white_48dp"
+        android:contentDescription="Floating Action Button" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/sample/src/main/res/layout/content_image.xml
+++ b/sample/src/main/res/layout/content_image.xml
@@ -15,7 +15,8 @@
             android:id="@+id/image_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scaleType="centerInside" />
+            android:scaleType="centerInside"
+            android:contentDescription="Main Image View" />
 
         <com.google.android.exoplayer2.ui.PlayerView
             android:id="@+id/exoPlayer"

--- a/sample/src/main/res/layout/content_image.xml
+++ b/sample/src/main/res/layout/content_image.xml
@@ -17,7 +17,7 @@
             android:layout_height="match_parent"
             android:scaleType="centerInside" />
 
-        <com.google.android.exoplayer2.ui.SimpleExoPlayerView
+        <com.google.android.exoplayer2.ui.PlayerView
             android:id="@+id/exoPlayer"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />

--- a/sample/src/main/res/layout/fragment_pager_page.xml
+++ b/sample/src/main/res/layout/fragment_pager_page.xml
@@ -24,10 +24,6 @@
             android:gravity="center"
             android:textSize="24sp" />
 
-        <androidx.legacy.widget.Space
-            android:layout_width="match_parent"
-            android:layout_height="16dp" />
-
         <Button
             android:id="@+id/emptyViewButton"
             android:layout_width="wrap_content"

--- a/sample/src/main/res/layout/item_effects_gallery.xml
+++ b/sample/src/main/res/layout/item_effects_gallery.xml
@@ -9,7 +9,8 @@
         android:layout_width="@dimen/effect_item_size"
         android:layout_height="@dimen/effect_item_size"
         android:layout_margin="@dimen/effect_item_margin"
-        android:scaleType="center" />
+        android:scaleType="center"
+        android:contentDescription="Main Image View" />
 
     <TextView
         android:id="@+id/effectName"

--- a/sample/src/main/res/layout/item_main_gallery.xml
+++ b/sample/src/main/res/layout/item_main_gallery.xml
@@ -7,7 +7,8 @@
         android:id="@+id/image_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:scaleType="center" />
+        android:scaleType="center"
+        android:contentDescription="Main Image" />
 
     <RelativeLayout
         android:id="@+id/buttonsContainer"
@@ -26,7 +27,8 @@
             android:layout_centerVertical="true"
             android:layout_margin="@dimen/default_margin"
             android:scaleType="centerInside"
-            android:src="@drawable/ic_delete_white_24dp" />
+            android:src="@drawable/ic_delete_white_24dp"
+            android:contentDescription="Delete Image" />
 
         <ImageView
             android:id="@+id/videoIcon"
@@ -36,7 +38,8 @@
             android:layout_centerVertical="true"
             android:layout_margin="@dimen/default_margin"
             android:scaleType="centerInside"
-            android:src="@drawable/ic_movie_white_24dp" />
+            android:src="@drawable/ic_movie_white_24dp"
+            android:contentDescription="Video Icon" />
 
     </RelativeLayout>
 
@@ -89,5 +92,6 @@
         android:layout_alignParentEnd="true"
         android:layout_alignParentTop="true"
         android:src="@drawable/ic_clear_white_24dp"
-        android:visibility="gone" />
+        android:visibility="gone"
+        android:contentDescription="Clear Buttom" />
 </RelativeLayout>

--- a/sample/src/main/res/layout/item_main_gallery_error.xml
+++ b/sample/src/main/res/layout/item_main_gallery_error.xml
@@ -13,7 +13,8 @@
             android:id="@+id/image_view"
             android:layout_width="@dimen/card_image_width"
             android:layout_height="match_parent"
-            android:scaleType="center" />
+            android:scaleType="center"
+            android:contentDescription="Main Image View" />
 
         <TextView
             android:id="@+id/filename"
@@ -65,6 +66,7 @@
             android:layout_alignParentEnd="true"
             android:layout_alignParentTop="true"
             android:layout_margin="@dimen/default_margin"
-            android:src="@drawable/ic_clear_black_24dp" />
+            android:src="@drawable/ic_clear_black_24dp"
+            android:contentDescription="Cancel Button" />
     </RelativeLayout>
 </androidx.cardview.widget.CardView>

--- a/sample/src/main/res/menu/main_menu.xml
+++ b/sample/src/main/res/menu/main_menu.xml
@@ -5,17 +5,17 @@
         android:id="@+id/menu_sync"
         android:icon="@drawable/ic_sync_white_24dp"
         android:title="@string/sync"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/menu_remove_from_cloud"
         android:icon="@drawable/ic_delete_white_24dp"
         android:title="@string/remove_from_cloud"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/menu_remove_from_local_album"
         android:icon="@drawable/ic_delete_white_24dp"
         android:title="@string/remove_from_local_album"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
 </menu>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">Cloudinary</string>
-    <string name="action_settings">Settings</string>
+    <string name="action_settings" tools:keep="@string/action_settings">Settings</string>
     <string name="no_cloud_error_message">Please configure your cloudinary url in your gradle-local.properties file in order to use this app</string>
     <string name="dialog_ok">OK</string>
     <string name="sync">Sync local media with cloud.</string>

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -1,16 +1,15 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion 31
+    buildToolsVersion "30.0.2"
 
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 29
+        minSdkVersion 19
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
         vectorDrawables.useSupportLibrary = true
@@ -23,6 +22,11 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
 }
 
 dependencies {
@@ -30,12 +34,12 @@ dependencies {
     implementation project(':core')
     implementation project(':preprocess')
 
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'com.google.android.material:material:1.4.0'
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }
 
 ext {

--- a/ui/src/main/java/com/cloudinary/android/uploadwidget/UploadWidget.java
+++ b/ui/src/main/java/com/cloudinary/android/uploadwidget/UploadWidget.java
@@ -125,7 +125,7 @@ public class UploadWidget {
      * @param requestCode A request code to start the native android picker with.
      */
     public static void openMediaChooser(Activity activity, int requestCode) {
-        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);

--- a/ui/src/main/java/com/cloudinary/android/uploadwidget/ui/UploadWidgetActivity.java
+++ b/ui/src/main/java/com/cloudinary/android/uploadwidget/ui/UploadWidgetActivity.java
@@ -72,7 +72,7 @@ public class UploadWidgetActivity extends AppCompatActivity implements UploadWid
                 ArrayList<Uri> uris = extractImageUris(data);
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                    final int takeFlags = data.getFlags() & (Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+                    final int takeFlags = data.getFlags() & (Intent.FLAG_GRANT_READ_URI_PERMISSION);
                     for (Uri uri : uris) {
                         if (DocumentsContract.isDocumentUri(this, uri)) {
                             getContentResolver().takePersistableUriPermission(uri, takeFlags);

--- a/ui/src/main/java/com/cloudinary/android/uploadwidget/ui/UploadWidgetFragment.java
+++ b/ui/src/main/java/com/cloudinary/android/uploadwidget/ui/UploadWidgetFragment.java
@@ -39,7 +39,6 @@ public class UploadWidgetFragment extends Fragment implements CropRotateFragment
 
 
     private static final String IMAGES_URIS_LIST_ARG = "images_uris_list_arg";
-    private FloatingActionButton uploadFab;
     private ViewPager mediaViewPager;
     private MediaPagerAdapter mediaPagerAdapter;
     private RecyclerView thumbnailsRecyclerView;
@@ -90,7 +89,7 @@ public class UploadWidgetFragment extends Fragment implements CropRotateFragment
             }
         });
 
-        uploadFab = view.findViewById(R.id.uploadFab);
+        FloatingActionButton uploadFab = view.findViewById(R.id.uploadFab);
         uploadFab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/ui/src/main/res/layout/activity_upload_widget.xml
+++ b/ui/src/main/res/layout/activity_upload_widget.xml
@@ -4,6 +4,6 @@
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.uploadwidget.ui.UploadWidgetActivity">
+    tools:context="com.cloudinary.android.uploadwidget.ui.UploadWidgetActivity">
 
 </RelativeLayout>

--- a/ui/src/main/res/layout/fragment_crop_rotate.xml
+++ b/ui/src/main/res/layout/fragment_crop_rotate.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/black"
-    tools:context=".ui.uploadwidget.ui.CropRotateFragment">
+    tools:context="com.cloudinary.android.uploadwidget.ui.CropRotateFragment">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/cropRotateToolbar"

--- a/ui/src/main/res/layout/fragment_upload_widget.xml
+++ b/ui/src/main/res/layout/fragment_upload_widget.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:background="@android:color/black"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    tools:context=".ui.uploadwidget.ui.UploadWidgetFragment">
+    tools:context="com.cloudinary.android.uploadwidget.ui.UploadWidgetFragment">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"


### PR DESCRIPTION
### Brief Summary of Changes
**What does this PR solve?**
This PR solves the need to remove Jcenter since it stops it support at the end of March 2022, this fix comes to solve the following issue: https://github.com/cloudinary/cloudinary_android/issues/122

### Root cause
The root cause for this PR is the need to remove dependency of the SDK on the Jcenter repo.

### Additional features
We increased the minimal Java version to 8
We increased the minimal Android SDK to 19

#### What does this PR address?
- [x] GitHub issue (Add reference - #XX)
- [x] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:


#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
