### PR TITLE
Set secure all http requests by default

### DIFF
--- a/core/src/main/java/com/cloudinary/android/MediaManager.java
+++ b/core/src/main/java/com/cloudinary/android/MediaManager.java
@@ -86,6 +86,9 @@ public class MediaManager {
             cloudinary = new Cloudinary();
         }
 
+        // set https as default for all http requests
+        cloudinary.config.secure = true;
+
         callbackDispatcher.registerCallback(new UploadCallback() {
 
             @Override
@@ -232,13 +235,6 @@ public class MediaManager {
      */
     public Url url() {
         Url url = cloudinary.url();
-
-        // set https as default for android P and up - in P the default policy fails all http
-        // requests
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            url.secure(true);
-        }
-
         return url;
     }
 


### PR DESCRIPTION
### Root cause:
As part of the Cloudinary Android SDK major release we want to set https requests as default.

### Implementation
The implementation is straight forward and easy, as part of the `MediaManager` initialisation we set `secure` variable in the `Configuration` to `true`.

This was already set for Android SDK >= 28.
All we had to do was remove the `if` condition and set it to all Android SDKS.

If a user would like to use `http` calls and not `https` he would need to set the following line after the `MediaManager` object has been initialized.

`MediaManager.get().getCloudinary().config.secure = false;`

There are currently 3 ways to set `secure` to `false` but since we dont want to change anything in the Java SDK we decided to go with this way.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:


#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
