### PR TITLE
Add Immultable flag to pending intent

### DIFF
--- a/sample/src/main/java/com/cloudinary/android/sample/app/CloudinaryService.java
+++ b/sample/src/main/java/com/cloudinary/android/sample/app/CloudinaryService.java
@@ -43,7 +43,6 @@ public class CloudinaryService extends ListenerService {
     private Notification.Builder builder;
     private Handler backgroundThreadHandler;
 
-    @SuppressLint("UnspecifiedImmutableFlag")
     @Override
     public void onCreate() {
         super.onCreate();
@@ -53,7 +52,7 @@ public class CloudinaryService extends ListenerService {
                 .setSmallIcon(R.drawable.ic_launcher)
                 .setContentIntent(PendingIntent.getActivity(this, 999,
                         new Intent(this, MainActivity.class).addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT).setAction(ACTION_STATE_IN_PROGRESS),
-                        0))
+                        PendingIntent.FLAG_IMMUTABLE))
                 .setOnlyAlertOnce(true)
                 .setOngoing(true);
 
@@ -72,7 +71,7 @@ public class CloudinaryService extends ListenerService {
         return null;
     }
 
-    @SuppressLint("UnspecifiedImmutableFlag")
+
     private Notification.Builder getBuilder(String requestId, Resource.UploadStatus status) {
          Notification.Builder builder = new Notification.Builder(this)
                 .setSmallIcon(R.drawable.ic_launcher)
@@ -80,7 +79,7 @@ public class CloudinaryService extends ListenerService {
                 .setContentIntent(PendingIntent.getActivity(this, 1234,
                         new Intent(this, MainActivity.class)
                                 .setAction(actionFromStatus(status))
-                        , 0))
+                        , PendingIntent.FLAG_IMMUTABLE))
                 .setLargeIcon(getBitmap(requestId));
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
### Brief Summary of Changes
Fixed pending intent flag to `PendingIntent.FLAG_IMMUTABLE`
According to the Android docs this is strongly recommend when creating pending event ([here](https://developer.android.com/reference/android/app/PendingIntent#:~:text=It%20is%20strongly%20recommended%20to,with%20inline%20reply%20or%20bubbles.))
Since the pending intent is used for local notification and does not require any changes we set its flag to `PendingIntent.FLAG_IMMUTABLE`
This change came following this [git issue](https://github.com/cloudinary/cloudinary_android/issues/137)

#### What does this PR address?
- [x] GitHub issue (Add reference - #137 )
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
