### PR TITLE
Fix Upload issue using WorkManager

### DIFF
--- a/core/src/androidTest/java/com/cloudinary/android/AndroidJobStrategyTest.java
+++ b/core/src/androidTest/java/com/cloudinary/android/AndroidJobStrategyTest.java
@@ -16,12 +16,25 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 
 @RunWith(AndroidJUnit4ClassRunner.class)
 public class AndroidJobStrategyTest extends AbstractTest {
+
+    private File payloadFile;
+
+    @Override
+    protected void finalize() throws Throwable {
+        super.finalize();
+
+        if(payloadFile != null) {
+            //noinspection ResultOfMethodCallIgnored
+            payloadFile.delete();
+        }
+    }
 
     @Test
     public void testAdapter() throws InterruptedException, IOException, NoSuchFieldException, IllegalAccessException {
@@ -30,7 +43,9 @@ public class AndroidJobStrategyTest extends AbstractTest {
         int tenMinutes = 10 * 60 * 1000;
         UploadRequest<FilePayload> request = buildUploadRequest(payload, tenMinutes);
 
-        WorkRequest adapted = AndroidJobStrategy.adapt(request);
+        payloadFile = File.createTempFile("payload", request.getRequestId());
+
+        WorkRequest adapted = AndroidJobStrategy.adapt(request, payloadFile);
         Class obj = adapted.getClass().getSuperclass();
         Field field = obj.getDeclaredField("mWorkSpec");
         field.setAccessible(true);


### PR DESCRIPTION
### Brief Summary of Changes
- Request payload is now stored under a temporary file, to which the absolute file path will be passed as Worker input Data. Worker will then pick up all these request payload from the file. This is to avoid the MAX_DATA_BYTES limit of 10240.

#### What does this PR address?
- [x] GitHub issue - https://github.com/cloudinary/cloudinary_android/issues/146
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
- This fix is a follow-up to a recent update(https://github.com/cloudinary/cloudinary_android/pull/145/)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
