### PR TITLE
Fix full backup content

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -2,5 +2,5 @@
     package="com.cloudinary.android.core">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <application android:fullBackupContent="@xml/backup_config" />
+    <application />
 </manifest>

--- a/core/src/main/res/xml/backup_config.xml
+++ b/core/src/main/res/xml/backup_config.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<full-backup-content>
-    <exclude domain="sharedpref" path="evernote_jobs.xml" />
-    <exclude domain="database" path="evernote_jobs.db" />
-</full-backup-content>


### PR DESCRIPTION
### Brief Summary of Changes
Remove `fullBackContent` from `<application>` in core AndroidManifest (We used it for `Evernote` and it was replaced by Android workmanager).

#### What does this PR address?
- [x] GitHub issue (Add reference - #100 )
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
