### PR TITLE
Migrate video player to Media3

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion "30.0.2"
 
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion "30.0.2"
 
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/download/build.gradle
+++ b/download/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion "30.0.2"
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/glide-integration/build.gradle
+++ b/glide-integration/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion "30.0.2"
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/preprocess/build.gradle
+++ b/preprocess/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion "30.0.2"
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         android.compileOptions.sourceCompatibility 1.8

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion "30.0.2"
 
     defaultConfig {
         applicationId "com.cloudinary.android.sample"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion "30.0.2"
 
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -35,7 +35,10 @@ dependencies {
     implementation project(':core')
     implementation project(':preprocess')
 
-    implementation 'com.google.android.exoplayer:exoplayer:2.16.0'
+    implementation 'androidx.media3:media3-exoplayer:1.1.1'
+    implementation 'androidx.media3:media3-exoplayer-dash:1.1.1'
+    implementation 'androidx.media3:media3-exoplayer-hls:1.1.1'
+    implementation 'androidx.media3:media3-ui:1.1.1'
 
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.google.android.material:material:1.4.0'

--- a/ui/src/androidTest/java/cloudinary/android/ui/CldVideoPlayerInstrumentedTest.java
+++ b/ui/src/androidTest/java/cloudinary/android/ui/CldVideoPlayerInstrumentedTest.java
@@ -1,4 +1,4 @@
-package cloudinary.android.sample;
+package cloudinary.android.ui;
 
 import android.content.Context;
 import android.os.Handler;
@@ -9,10 +9,11 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.runner.AndroidJUnit4;
 
 import com.cloudinary.Transformation;
+import com.cloudinary.android.MediaManager;
 import com.cloudinary.android.cldvideoplayer.CldVideoPlayer;
-import com.google.android.exoplayer2.ExoPlayer;
 
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -26,6 +27,12 @@ import java.util.concurrent.TimeUnit;
 public class CldVideoPlayerInstrumentedTest {
 
     private Context context;
+
+    @BeforeClass
+    public synchronized static void initLibrary() {
+        MediaManager.init(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        MediaManager.get().getCloudinary().config.cloudName = "demo";
+    }
 
     @Before
     public void setUp() {

--- a/ui/src/main/java/com/cloudinary/android/cldvideoplayer/CldVideoPlayer.java
+++ b/ui/src/main/java/com/cloudinary/android/cldvideoplayer/CldVideoPlayer.java
@@ -3,11 +3,12 @@ package com.cloudinary.android.cldvideoplayer;
 import android.content.Context;
 import android.util.Log;
 
+import androidx.media3.common.MediaItem;
+import androidx.media3.exoplayer.ExoPlayer;
+
 import com.cloudinary.Cloudinary;
 import com.cloudinary.Transformation;
 import com.cloudinary.android.MediaManager;
-import com.google.android.exoplayer2.ExoPlayer;
-import com.google.android.exoplayer2.MediaItem;
 
 import java.net.URL;
 


### PR DESCRIPTION
### Brief Summary of Changes
Upgrade video player widget to use Media3 exoplayer since exoplayer2 is deprecated and discontinued (see [here](https://github.com/google/ExoPlayer)) 

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [x] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
