### PR TITLE
Feature: Upgrade Api Level to 34 

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -1,14 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdk 33
+    compileSdk 34
 
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 33
-        versionCode 1
-        versionName "1.0"
+        targetSdkVersion 34
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ allprojects {
         }
 
         dependencies {
-            classpath 'com.android.tools.build:gradle:7.0.4'
+            classpath 'com.android.tools.build:gradle:7.1.2'
             classpath "de.marcphilipp.gradle:nexus-publish-plugin:0.4.0"
             classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.1"
             classpath 'digital.wup:android-maven-publish:3.6.2'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,14 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdk 33
+    compileSdk 34
 
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 33
-        versionCode 1
-        versionName "1.0"
+        targetSdkVersion 34
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // filter in the api credentials before building but without changing original source

--- a/download/build.gradle
+++ b/download/build.gradle
@@ -1,13 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 33
-        versionCode 1
-        versionName "1.0"
+        targetSdkVersion 34
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'

--- a/glide-integration/build.gradle
+++ b/glide-integration/build.gradle
@@ -1,13 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 33
-        versionCode 1
-        versionName "1.0"
+        targetSdkVersion 34
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jan 19 11:45:39 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/preprocess/build.gradle
+++ b/preprocess/build.gradle
@@ -1,13 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 33
-        versionCode 1
-        versionName "1.0"
+        targetSdkVersion 34
         android.compileOptions.sourceCompatibility 1.8
         android.compileOptions.targetCompatibility 1.8
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -7,10 +7,10 @@ android {
     }
 
     defaultConfig {
-        compileSdk 33
+        compileSdk 34
         applicationId "com.cloudinary.sample"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -26,7 +26,6 @@ android {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            consumerProguardFiles 'proguard-rules.pro'
         }
     }
 

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -1,14 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdk 33
+    compileSdk 34
 
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 33
-        versionCode 1
-        versionName "1.0"
+        targetSdkVersion 34
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
### Brief Summary of Changes
This pull request includes several updates to the Android build configuration across multiple modules. The main changes involve upgrading the `compileSdk` and `targetSdkVersion` to 34 and updating the Gradle wrapper version.

#### What does this PR address?
- [X] GitHub issue - #178
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [X] No

#### Reviewer, please note:
Following the upgrade to API 34, I encountered the following error:

> AAPT2 aapt2-7.0.4-7396180-windows Daemon #0: Unexpected error during link, attempting to stop daemon.

To resolve it, I had to upgrade AGP to 7.1.2 [[Reference](https://stackoverflow.com/questions/67233807/android-gradle-build-error-aapt2-aapt2-4-1-0-6503028-windows-daemon-0-unexpec)] and Gradle to 7.2.


#### Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I ran the full test suite before pushing the changes and all the tests pass.
